### PR TITLE
fix import generation on windows

### DIFF
--- a/pkg/generator/pkg.go
+++ b/pkg/generator/pkg.go
@@ -70,6 +70,7 @@ func (tr *Transport) pkgPath(dir string) (pkgPath string) {
 	dirAbs, _ := filepath.Abs(dir)
 	if modPath, err := mod.GoModPath(dir); err == nil {
 		pkgDir = strings.TrimPrefix(dirAbs, filepath.Dir(modPath))
+		pkgDir = strings.ReplaceAll(pkgDir, "\\", "/")
 	}
 	return tr.module.Module.Mod.String() + pkgDir
 }


### PR DESCRIPTION
Fixing the issue related import generation on windows. Tt can generate import like this:

`	"repo.example.com/some/project/internal/transport\viewer"
`
(it is incorrect).

Now it just replace '\\' to '/'