### PR TITLE
Replacing fmt.Errorf in unformatted message passing

### DIFF
--- a/pkg/generator/client-jsonrpc.go
+++ b/pkg/generator/client-jsonrpc.go
@@ -86,7 +86,7 @@ func (tr *Transport) jsonrpcClientProceedResponseFunc(outDir string) Code {
 					If(Id("cli").Dot("errorDecoder").Op("!=").Nil()).Block(
 						Err().Op("=").Id("cli").Dot("errorDecoder").Call(Id("rpcResponse").Dot("Error").Dot("Raw").Call()),
 					).Else().Block(
-						Err().Op("=").Qual(packageFmt, "Errorf").Call(Id("rpcResponse").Dot("Error").Dot("Message")),
+						Err().Op("=").Qual(packageErrors, "New").Call(Id("rpcResponse").Dot("Error").Dot("Message")),
 					),
 					Return(),
 				),

--- a/pkg/generator/service-jsonrpc-client.go
+++ b/pkg/generator/service-jsonrpc-client.go
@@ -84,7 +84,7 @@ func (svc *service) jsonrpcClientMethodFunc(ctx context.Context, method *method,
 				If(Id("cli").Dot("errorDecoder").Op("!=").Nil()).Block(
 					Err().Op("=").Id("cli").Dot("errorDecoder").Call(Id("rpcResponse").Dot("Error").Dot("Raw").Call()),
 				).Else().Block(
-					Err().Op("=").Qual(packageFmt, "Errorf").Call(Id("rpcResponse").Dot("Error").Dot("Message")),
+					Err().Op("=").Qual(packageErrors, "New").Call(Id("rpcResponse").Dot("Error").Dot("Message")),
 				),
 				Return(),
 			)
@@ -146,7 +146,7 @@ func (svc *service) jsonrpcClientRequestFunc(ctx context.Context, method *method
 							If(Id("cli").Dot("errorDecoder").Op("!=").Nil()).Block(
 								Err().Op("=").Id("cli").Dot("errorDecoder").Call(Id("rpcResponse").Dot("Error").Dot("Raw").Call()),
 							).Else().Block(
-								Err().Op("=").Qual(packageFmt, "Errorf").Call(Id("rpcResponse").Dot("Error").Dot("Message")),
+								Err().Op("=").Qual(packageErrors, "New").Call(Id("rpcResponse").Dot("Error").Dot("Message")),
 							),
 						).Else().Block(
 							Err().Op("=").Id("rpcResponse").Dot("GetObject").Call(Op("&").Add(resp)),
@@ -166,7 +166,7 @@ func (svc *service) jsonrpcClientRequestFunc(ctx context.Context, method *method
 							If(Id("cli").Dot("errorDecoder").Op("!=").Nil()).Block(
 								Err().Op("=").Id("cli").Dot("errorDecoder").Call(Id("rpcResponse").Dot("Error").Dot("Raw").Call()),
 							).Else().Block(
-								Err().Op("=").Qual(packageFmt, "Errorf").Call(Id("rpcResponse").Dot("Error").Dot("Message")),
+								Err().Op("=").Qual(packageErrors, "New").Call(Id("rpcResponse").Dot("Error").Dot("Message")),
 							),
 						).Else().Block(
 							Err().Op("=").Id("rpcResponse").Dot("GetObject").Call(Op("&").Add(resp)),


### PR DESCRIPTION
After updating go version up to `1.24` version most of generated json rpc clients started being the source of test failures. The reason is that the generated code contains `fmt.Errorf` with passing an unformatted message. Since `1.24` version go requires _non-constant format strings to be explicitly handled_. This PR replaces the creation of errors through an explicit method - `errors.New`